### PR TITLE
fix: resolve CI workflow failures and remove all linter/test suppressions

### DIFF
--- a/.claude/skills/ci-status/SKILL.md
+++ b/.claude/skills/ci-status/SKILL.md
@@ -1,0 +1,150 @@
+# ci-status — Fetch GitHub Actions Results & Diagnose Failures
+
+Fetches the latest GitHub Actions workflow runs for the **current branch** (or
+a specified PR/branch/run), shows pass/fail status per job, and pulls the
+relevant log lines for any failures so you can diagnose and fix them.
+
+## How to use
+
+```
+/ci-status                  # latest run on current branch
+/ci-status 18               # latest run for PR #18's branch
+/ci-status run 15234567890  # specific run ID
+```
+
+## GitHub repo
+
+`dodoflix/tacoshell` on `api.github.com`
+
+---
+
+## Step-by-step instructions
+
+### 1. Determine the branch
+
+If an explicit run ID was given, skip to step 3.
+
+If a PR number was given, resolve its head branch:
+
+```bash
+curl -s "https://api.github.com/repos/dodoflix/tacoshell/pulls/<PR>" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['head']['ref'])"
+```
+
+Otherwise use the current branch:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+### 2. Find the latest workflow run for that branch
+
+```bash
+BRANCH=<branch>
+curl -s "https://api.github.com/repos/dodoflix/tacoshell/actions/runs?branch=${BRANCH}&per_page=5" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for r in data.get('workflow_runs', []):
+    print(r['id'], r['name'], r['status'], r['conclusion'], r['html_url'])
+"
+```
+
+Pick the most recent run (first entry). Note its `id`.
+
+### 3. List jobs for that run
+
+```bash
+RUN_ID=<run_id>
+curl -s "https://api.github.com/repos/dodoflix/tacoshell/actions/runs/${RUN_ID}/jobs?per_page=50" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for j in data.get('jobs', []):
+    status    = j['status']
+    conclusion= j.get('conclusion') or 'in_progress'
+    name      = j['name']
+    jid       = j['id']
+    icon      = '✓' if conclusion == 'success' else ('✗' if conclusion == 'failure' else '·')
+    print(f'{icon} [{jid}] {name} — {conclusion}')
+    if conclusion == 'failure':
+        for step in j.get('steps', []):
+            if step.get('conclusion') == 'failure':
+                print(f'      FAILED STEP: {step[\"name\"]}')
+"
+```
+
+### 4. Fetch logs for each failed job
+
+For every job with `conclusion == 'failure'`:
+
+```bash
+JOB_ID=<job_id>
+curl -sL "https://api.github.com/repos/dodoflix/tacoshell/actions/jobs/${JOB_ID}/logs" 2>&1 \
+  | grep -E "(error|Error|FAILED|fatal|warning|Warning|##\[)" \
+  | tail -80
+```
+
+If the log redirect requires following, add `-L` (already included above).
+
+Note: GitHub returns a redirect to a pre-signed Azure Blob URL for logs. `curl -sL` follows it automatically.
+
+### 5. Diagnose
+
+Print a structured report:
+
+```
+RUN #<id> — <workflow name> — <conclusion>
+Branch: <branch>
+Triggered: <created_at>
+
+JOBS:
+  ✓ Lint
+  ✗ Rust Tests (ubuntu-latest)
+      FAILED STEP: cargo test
+  ✓ TypeScript Tests
+  · Build Desktop (skipped)
+
+FAILURE DETAILS — Rust Tests (ubuntu-latest):
+  <relevant log lines>
+```
+
+### 6. Fix (if asked or obviously actionable)
+
+If the failure is in this repo's code (not a flaky network issue or missing
+secret), read the relevant file(s) and apply a fix following the project's
+TDD and no-suppression rules.
+
+If the failure needs a secret or external config, report it clearly and stop.
+
+### 7. Commit & push (if fixes were made)
+
+```bash
+git add <changed files>
+git commit -m "fix: resolve CI failure in <job name>\n\n<what was wrong and how it was fixed>\n\nhttps://claude.ai/code/session_..."
+git push -u origin <branch>
+```
+
+---
+
+## Useful API reference
+
+| What | Endpoint |
+|------|----------|
+| List runs for branch | `GET /repos/dodoflix/tacoshell/actions/runs?branch=<branch>&per_page=5` |
+| Single run | `GET /repos/dodoflix/tacoshell/actions/runs/<run_id>` |
+| Jobs for run | `GET /repos/dodoflix/tacoshell/actions/runs/<run_id>/jobs?per_page=50` |
+| Job logs (redirects) | `GET /repos/dodoflix/tacoshell/actions/jobs/<job_id>/logs` |
+| PR head branch | `GET /repos/dodoflix/tacoshell/pulls/<pr>` → `.head.ref` |
+
+All endpoints are unauthenticated for public repos. If rate-limited (HTTP 403
+with `X-RateLimit-Remaining: 0`), wait and retry or add `-H "Authorization:
+token <GITHUB_TOKEN>"` using a token from the environment.
+
+## Notes
+
+- Always check **all failed jobs**, not just the first one.
+- Log output from `curl -sL` on the jobs/logs endpoint may be plain text or
+  URL-encoded — pipe through `python3 -c "import sys; print(sys.stdin.read())"` if needed.
+- Flaky failures (network timeouts, Docker pull failures) should be noted but
+  not "fixed" in code — report them to the user instead.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,132 @@
+# review-pr — Fetch & Fix PR Review Comments
+
+Fetches all review comments (inline code comments) and general PR comments from
+GitHub for the **current branch's PR**, then evaluates and fixes the valid ones.
+
+## How to use
+
+```
+/review-pr          # auto-detect PR from current branch
+/review-pr 18       # explicit PR number
+```
+
+## GitHub repo
+
+`dodoflix/tacoshell` on `api.github.com`
+
+## Step-by-step instructions
+
+### 1. Determine the PR number
+
+If an argument is given, use it directly.
+
+Otherwise, run:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+Then find the PR number from the remote PR refs:
+
+```bash
+git ls-remote origin 'refs/pull/*/head' | grep $(git rev-parse HEAD) | grep -oP 'refs/pull/\K[0-9]+'
+```
+
+If that doesn't match (e.g. new commits since last push), list all open PR refs
+and match on branch name via:
+
+```bash
+git ls-remote origin 'refs/pull/*/head'
+```
+
+Cross-reference with local branch name using:
+
+```bash
+git branch -r | grep <branch-name>
+```
+
+### 2. Fetch inline code review comments
+
+```bash
+curl -s "https://api.github.com/repos/dodoflix/tacoshell/pulls/<PR>/comments" \
+  | python3 -c "
+import sys, json
+comments = json.load(sys.stdin)
+for c in comments:
+    user = c['user']['login']
+    path = c.get('path', '')
+    line = c.get('line') or c.get('original_line', '')
+    body = c.get('body', '')
+    cid  = c.get('id', '')
+    print(f'ID:{cid} | {user} | {path}:{line}')
+    print(body)
+    print('---')
+"
+```
+
+### 3. Fetch general PR (issue) comments
+
+```bash
+curl -s "https://api.github.com/repos/dodoflix/tacoshell/issues/<PR>/comments" \
+  | python3 -c "
+import sys, json
+comments = json.load(sys.stdin)
+for c in comments:
+    user = c['user']['login']
+    body = c.get('body', '')
+    cid  = c.get('id', '')
+    print(f'ID:{cid} | {user} | (general comment)')
+    print(body)
+    print('---')
+"
+```
+
+### 4. Evaluate each comment
+
+For every comment, decide:
+
+| Verdict | Criteria | Action |
+|---------|----------|--------|
+| **Fix** | Technically correct — real bug, missing dep, wrong type, security issue, logic error | Read the referenced file, apply the fix |
+| **Skip** | Style preference with no correctness impact, already addressed, or out of date | Note it, move on |
+| **Discuss** | Ambiguous — needs user input | Surface it to the user |
+
+Key rule: **never suppress a warning to silence a comment** — always fix the
+underlying issue.
+
+### 5. Apply fixes
+
+For each comment being fixed:
+- Read the file at the referenced path
+- Make the minimal, correct change
+- Do not reformat unrelated lines
+
+### 6. Commit and push
+
+After all fixes are applied:
+
+```bash
+git add <changed files>
+git commit -m "fix: address PR review comments\n\n<bullet list of what was fixed>\n\nhttps://claude.ai/code/session_..."
+git push -u origin <branch>
+```
+
+### 7. Report
+
+Print a summary table:
+
+```
+FIXED:
+  - packages/ui/package.json — replaced happy-dom with jsdom devDependency (Copilot)
+
+SKIPPED:
+  - (none)
+```
+
+## Notes
+
+- The GitHub API for public repos doesn't require auth for read-only access —
+  no token is needed unless the repo is private or rate-limited.
+- Both endpoint types must be checked: `/pulls/<n>/comments` (inline) and
+  `/issues/<n>/comments` (general thread).
+- Always re-read the file before editing — never edit blind.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,15 +251,16 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
             librsvg2-dev patchelf libssl-dev pkg-config
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
+          cache: pnpm
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -298,15 +299,16 @@ jobs:
       - name: Build WASM
         run: wasm-pack build packages/core-wasm --target web --release
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
+          cache: pnpm
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,14 @@ jobs:
           jq --arg v "$VERSION" '.version = $v' packages/core-wasm/pkg/package.json > tmp.json
           mv tmp.json packages/core-wasm/pkg/package.json
 
+      - name: Set up Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to npm
-        run: wasm-pack publish packages/core-wasm/pkg
+        run: npm publish packages/core-wasm/pkg --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -167,6 +173,7 @@ jobs:
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-latest
+    needs: [release-desktop, release-wasm, release-web]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,18 @@ Follow Conventional Commits: `feat:`, `fix:`, `test:`, `docs:`, `chore:`, `refac
 - New GitHub API calls must not request scopes beyond `repo` and `read:user`
 - Run `cargo audit` before merging any dependency changes
 
+## No Suppression Policy (Non-negotiable)
+
+Never suppress, silence, or ignore any warning, error, or alert — fix it or refactor the code. This applies to all languages and tooling:
+
+- **TypeScript/ESLint:** No `eslint-disable`, `eslint-disable-next-line`, `@ts-ignore`, or `@ts-expect-error`
+- **Rust:** No `#[allow(...)]` Clippy attributes in non-test production code — fix the underlying issue
+- **Tests:** No `console.error = ...` or `console.warn = ...` patches in test setup files — fix the root cause (e.g. switch test environments, fix component accessibility, update the tool)
+- **Git:** Never use `--no-verify` to skip hooks — fix what the hook is reporting
+- **General:** No `// TODO: remove once upstream fixes...` workarounds left unresolved — either fix it now or open a tracked issue
+
+If a tool produces a false-positive, fix the root cause (e.g. switch to a more compatible test environment, add a proper type, restructure the code) rather than silencing the warning.
+
 ## Current Phase
 
 See `TODO.md` for the active task list. Check off items as they are completed.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^9.0.0",
-    "happy-dom": "^14.12.0",
+    "jsdom": "^24.0.0",
     "msw": "^2.3.0",
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.0",

--- a/packages/ui/src/stores/useVaultStore.ts
+++ b/packages/ui/src/stores/useVaultStore.ts
@@ -5,8 +5,7 @@ export type VaultItemType = 'connection_profile' | 'ssh_key' | 'password' | 'kub
 export interface VaultItem {
   id: string
   type: VaultItemType
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  payload: Record<string, any>
+  payload: Record<string, unknown>
   createdAt: string
   updatedAt: string
 }

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,13 +1,1 @@
 import '@testing-library/jest-dom'
-
-// Suppress known false-positive Radix UI accessibility warning in the test environment.
-// In happy-dom, Dialog portals render outside the component tree, causing Radix's
-// DialogTitle detection to fail even when a DialogTitle IS present in the component.
-// Radix logs: "`DialogContent` requires a `DialogTitle` for the component to be accessible…"
-// TODO: remove once https://github.com/radix-ui/primitives/issues/1103 is resolved upstream.
-const originalConsoleError = console.error.bind(console)
-console.error = (...args: unknown[]) => {
-  const msg = typeof args[0] === 'string' ? args[0] : ''
-  if (msg.startsWith('`DialogContent` requires a `DialogTitle`')) return
-  originalConsoleError(...args)
-}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     alias: { '@': resolve(__dirname, 'src') },
   },
   test: {
-    environment: 'happy-dom',
+    environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test-setup.ts'],
     coverage: {


### PR DESCRIPTION
- ci.yml: upgrade pnpm/action-setup from @v3 to @v4 in build-desktop and
  build-web jobs; move pnpm install before setup-node and add cache: pnpm
  to match the working lint/test-typescript job pattern
- release.yml: add actions/setup-node with registry-url before npm publish
  so NODE_AUTH_TOKEN is properly injected into .npmrc; switch from
  wasm-pack publish to npm publish --access public; add
  needs: [release-desktop, release-wasm, release-web] to changelog job to
  prevent it racing other release jobs
- packages/ui/vitest.config.ts: switch test environment from happy-dom to
  jsdom so Radix UI portal semantics work correctly in tests
- packages/ui/src/test-setup.ts: remove console.error suppression — the
  root cause was happy-dom; jsdom renders portals correctly so no patch needed
- packages/ui/src/stores/useVaultStore.ts: replace Record<string, any> with
  Record<string, unknown> and remove eslint-disable-next-line comment
- CLAUDE.md: add No Suppression Policy section documenting that warnings,
  errors, and alerts must always be fixed — never silenced or ignored

https://claude.ai/code/session_01TPpvG2ftqSdEbZGEBFhXwn